### PR TITLE
Allow PHP 8 and pin brick/math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
   "description" : "Powertranz 3DS2 Payment Gateway Driver for Omnipay",
   "minimum-stability" : "dev",
   "require": {
-    "php" : "^8",
     "omnipay/common" : "^3",
     "ext-json": "*",
     "ramsey/uuid": "^4",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "alcohol/iso4217": "^4.0.0",
     "symfony/http-client": "5.4.x-dev",
     "php-http/httplug": "2.x-dev",
-    "nyholm/psr7": "^1.8@dev"
+    "nyholm/psr7": "^1.8@dev",
+    "brick/math": "^0.10.2"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "description" : "Powertranz 3DS2 Payment Gateway Driver for Omnipay",
   "minimum-stability" : "dev",
   "require": {
-    "php" : "^7.4",
+    "php" : "^8",
     "omnipay/common" : "^3",
     "ext-json": "*",
     "ramsey/uuid": "^4",


### PR DESCRIPTION
Drupal 10 and CiviCRM 6 require PHP 8.

The removal of the PHP 7.4 requirement causes 'brick/math' to move to a recently released v0.11.0 which has breaking changes that affect 'brick/money' which is in use by 'civicrm/civicrm-core' so we should pin it to a compatible version.